### PR TITLE
cluster.sh: fix PROJECT env to PROJECT_ID

### DIFF
--- a/cluster.sh
+++ b/cluster.sh
@@ -6,6 +6,6 @@ if [ -z "${PROJECT_ID}" ]; then
 fi
 
 gcloud container clusters create test-trace-cluster \
-       --project $PROJECT \
+       --project $PROJECT_ID \
        --zone us-west1-b \
        --scopes default,bigquery,cloud-platform,compute-rw,datastore,logging-write,monitoring-write


### PR DESCRIPTION
Currently, `gcloud` command will occur `ERROR: (gcloud.container.clusters.create) argument --project: expected one argument` error.
fix `PROJECT` env to `PROJECT_ID`.